### PR TITLE
Make queue URLs based on "Host" header of incoming request

### DIFF
--- a/elasticmq.conf
+++ b/elasticmq.conf
@@ -1,5 +1,14 @@
 include classpath("application.conf")
 
+// node-address.host = "*" means the server will take "Host" header of incoming
+// requests to generate queue URLs.
+node-address {
+    protocol = http
+    host = "*"
+    port = 9324
+    context-path = ""
+}
+
 queues {
   queue1 {}
 }


### PR DESCRIPTION
This setting makes more sense in docker environment, where services can have multiple IPs or DNS names at the same time.